### PR TITLE
add packet length verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:membrane_rtsp, "~> 0.3.3"}
+    {:membrane_rtsp, "~> 0.4.0"}
   ]
 end
 ```

--- a/lib/membrane_rtsp/response.ex
+++ b/lib/membrane_rtsp/response.ex
@@ -62,7 +62,7 @@ defmodule Membrane.RTSP.Response do
          body_size <- byte_size(body),
          {:ok, content_legth_str} <-
            get_header(%__MODULE__{response | headers: headers}, "Content-Length") do
-      {content_length, _} = Integer.parse(content_legth_str)
+      {content_length, _remainder} = Integer.parse(content_legth_str)
 
       if body_size == content_length do
         {:ok, content_length, body_size}
@@ -71,7 +71,7 @@ defmodule Membrane.RTSP.Response do
       end
     else
       {:error, :no_such_header} -> {:ok, 0, byte_size(body)}
-      _ -> {:error, 0, byte_size(body)}
+      _other -> {:error, 0, byte_size(body)}
     end
   end
 

--- a/lib/membrane_rtsp/response.ex
+++ b/lib/membrane_rtsp/response.ex
@@ -51,6 +51,29 @@ defmodule Membrane.RTSP.Response do
   ```
 
   """
+  @spec verify_content_length(binary()) ::
+          {:ok, non_neg_integer(), non_neg_integer()}
+          | {:error, non_neg_integer(), non_neg_integer()}
+  def verify_content_length(response) do
+    [headers, body] = String.split(response, ["\r\n\r\n", "\n\n", "\r\r"], parts: 2)
+
+    with {:ok, {response, headers}} <- parse_start_line(headers),
+         {:ok, headers} <- parse_headers(headers),
+         body_size <- byte_size(body),
+         {:ok, content_legth_str} <-
+           get_header(%__MODULE__{response | headers: headers}, "Content-Length") do
+      {content_length, _} = Integer.parse(content_legth_str)
+
+      if body_size == content_length do
+        {:ok, content_length, body_size}
+      else
+        {:error, content_length, body_size}
+      end
+    else
+      {:error, :no_such_header} -> {:ok, 0, byte_size(body)}
+      _ -> {:error, 0, byte_size(body)}
+    end
+  end
 
   @spec get_header(__MODULE__.t(), binary()) :: {:error, :no_such_header} | {:ok, binary()}
   def get_header(%__MODULE__{headers: headers}, name) do

--- a/lib/membrane_rtsp/response.ex
+++ b/lib/membrane_rtsp/response.ex
@@ -49,9 +49,9 @@ defmodule Membrane.RTSP.Response do
           {:ok, non_neg_integer(), non_neg_integer()}
           | {:error, non_neg_integer(), non_neg_integer()}
   def verify_content_length(response) do
-    splittet_response = String.split(response, ["\r\n\r\n", "\n\n", "\r\r"], parts: 2)
-    headers = Enum.at(splittet_response, 0)
-    body = Enum.at(splittet_response, 1)
+    split_response = String.split(response, ["\r\n\r\n", "\n\n", "\r\r"], parts: 2)
+    headers = Enum.at(split_response, 0)
+    body = Enum.at(split_response, 1)
 
     with {:ok, {response, headers}} <- parse_start_line(headers),
          {:ok, headers} <- parse_headers(headers),

--- a/lib/membrane_rtsp/response.ex
+++ b/lib/membrane_rtsp/response.ex
@@ -57,7 +57,7 @@ defmodule Membrane.RTSP.Response do
   def verify_content_length(response) do
     splittet_response = String.split(response, ["\r\n\r\n", "\n\n", "\r\r"], parts: 2)
     headers = Enum.at(splittet_response, 0)
-    body = Enum.at(splittet_response, 0) || ""
+    body = Enum.at(splittet_response, 1) || ""
     body_size = byte_size(body)
 
     with {:ok, {response, headers}} <- parse_start_line(headers),

--- a/lib/membrane_rtsp/transport/tcp_socket.ex
+++ b/lib/membrane_rtsp/transport/tcp_socket.ex
@@ -52,12 +52,12 @@ defmodule Membrane.RTSP.Transport.TCPSocket do
   @impl true
   def close(_state), do: :ok
 
-  defp recv(socket) do
-    case do_recv(socket) do
+  defp recv(socket, length \\ 0, acc \\ <<>>) do
+    case do_recv(socket, length, acc) do
       {:ok, data} ->
         case Membrane.RTSP.Response.verify_content_length(data) do
           {:ok, _expected, _received} -> {:ok, data}
-          {:error, expected, received} -> do_recv(socket, expected - received, data)
+          {:error, expected, received} -> recv(socket, expected - received, data)
         end
 
       {:error, reason} ->

--- a/lib/membrane_rtsp/transport/tcp_socket.ex
+++ b/lib/membrane_rtsp/transport/tcp_socket.ex
@@ -65,7 +65,7 @@ defmodule Membrane.RTSP.Transport.TCPSocket do
     end
   end
 
-  defp do_recv(socket, length \\ 0, acc \\ <<>>) do
+  defp do_recv(socket, length, acc) do
     case mockable(:gen_tcp).recv(socket, length, @tcp_receive_timeout) do
       {:ok, data} -> {:ok, acc <> data}
       {:error, reason} -> {:error, reason}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTSP.MixProject do
   use Mix.Project
 
-  @version "0.3.3"
+  @version "0.4.0"
   @github_url "https://github.com/membraneframework/membrane_rtsp"
 
   def project do


### PR DESCRIPTION
A previous temporary solution was problematic, especially for slower connections (I've often hit timeout waiting for the next packet).

Issue:
We discovered that some RTPS servers (e.g. Oupree Cam) tend to send some RTSP packed in two TCP packets that we need to receive separately. It happens mostly in response to DESCRIBE requests when we expect to get SDP info. An answer is sent in two packets, the first containing header and the second containing body. Original solution was only waiting for the first message from `:gen_tcp`. A hotfix by @varsill was collecting all until we get a timeout. It was problematic, especially for slower connections - I've often hit timeout waiting for the next packet. And also for fast connections, we were slowing them down without reason by waiting for a timeout.

Solution:
I've changed the socket to passive mode to manually consume messages, and add verification of content that we already received by comparing the `content-length` header value ([https://www.rfc-editor.org/rfc/rfc2326.html#section-12.14
](https://www.rfc-editor.org/rfc/rfc2326.html#section-12.14
)) with the length of the body we received. And if it's not equal, we're waiting for the next portion to come

CC @sgfn
