### PR TITLE
Fix path bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:membrane_rtsp, "~> 0.10.0"}
+    {:membrane_rtsp, "~> 0.10.1"}
   ]
 end
 ```

--- a/lib/membrane_rtsp/rtsp.ex
+++ b/lib/membrane_rtsp/rtsp.ex
@@ -204,7 +204,7 @@ defmodule Membrane.RTSP do
     case URI.parse(url) do
       %URI{host: host, scheme: "rtsp"} = url when is_binary(host) ->
         start_fun.(__MODULE__, %{
-          url: %URI{url | port: url.port || @default_rtsp_port},
+          url: %URI{url | port: url.port || @default_rtsp_port, path: url.path || "/"},
           options: options
         })
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTSP.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
   @github_url "https://github.com/membraneframework/membrane_rtsp"
 
   def project do


### PR DESCRIPTION
When sending requests to an URI that, when parsed, has `path` field set to `nil` (e.g. rtsp://localhost:8554), there would be a crash in [`lib/membrane_rtsp/request.ex:173`](https://github.com/membraneframework/membrane_rtsp/blob/4bf32ce599db65cd0b4ccbe39201b3e6d7256711/lib/membrane_rtsp/request.ex#L173) by trying to call `Path.relative_to/2` with first argument of `nil`. 

This PR fixes this by setting the path to `"/"` if parsing of the provided URI resolves it to `nil`.