### PR TITLE
Add support for announce and record to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![CircleCI](https://circleci.com/gh/membraneframework/membrane_rtsp.svg?style=svg)](https://circleci.com/gh/membraneframework/membrane_rtsp)
 
 
-The RTSP client for Elixir
+The RTSP client and server for Elixir
 
-Currently supports only RTSP 1.1 defined by
+Currently supports only RTSP 1.0 defined by
 [RFC2326](https://tools.ietf.org/html/rfc2326)
 
 ## Installation

--- a/lib/membrane_rtsp/parser.ex
+++ b/lib/membrane_rtsp/parser.ex
@@ -32,12 +32,16 @@ defmodule Membrane.RTSP.Parser do
           {:ok, RTSP.Request.transport_header()} | {:error, :invalid_header}
   def parse_transport_header(header) do
     case Transport.parse_transport_header(header) do
-      {:ok, [transport, mode | parameters], _rest, _context, _line, _byte_offset} ->
+      {:ok, [transport, network_mode | parameters], _rest, _context, _line, _byte_offset} ->
+        parameters = Map.new(parameters)
+        mode = String.downcase(parameters["mode"] || "play")
+
         {:ok,
          [
            transport: String.to_atom(transport),
+           network_mode: String.to_atom(network_mode),
            mode: String.to_atom(mode),
-           parameters: Map.new(parameters)
+           parameters: Map.delete(parameters, "mode")
          ]}
 
       {:error, _reason, _rest, _context, _line, _byte_offset} ->

--- a/lib/membrane_rtsp/request.ex
+++ b/lib/membrane_rtsp/request.ex
@@ -17,7 +17,8 @@ defmodule Membrane.RTSP.Request do
 
   @type transport_header :: [
           transport: :TCP | :UDP,
-          mode: :unicast | :multicast,
+          network_mode: :unicast | :multicast,
+          mode: :play | :record,
           parameters: map()
         ]
 
@@ -123,19 +124,19 @@ defmodule Membrane.RTSP.Request do
   ```
     iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AVP;unicast;client_port=30001-30002"}]}
     iex> Request.parse_transport_header(req)
-    {:ok, [transport: :UDP, mode: :unicast, parameters: %{"client_port" => {30001, 30002}}]}
+    {:ok, [transport: :UDP, network_mode: :unicast, mode: :play, parameters: %{"client_port" => {30001, 30002}}]}
 
     iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AVP;ttl=15"}]}
     iex> Request.parse_transport_header(req)
-    {:ok, [transport: :UDP, mode: :multicast, parameters: %{"ttl" => 15}]}
+    {:ok, [transport: :UDP, network_mode: :multicast, mode: :play, parameters: %{"ttl" => 15}]}
 
-    iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AVP/TCP;unicast;interleaved=0-1"}]}
+    iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AVP/TCP;unicast;interleaved=0-1;mode=record"}]}
     iex> Request.parse_transport_header(req)
-    {:ok, [transport: :TCP, mode: :unicast, parameters: %{"interleaved" => {0, 1}}]}
+    {:ok, [transport: :TCP, network_mode: :unicast, mode: :record, parameters: %{"interleaved" => {0, 1}}]}
 
     iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AVP"}]}
     iex> Request.parse_transport_header(req)
-    {:ok, [transport: :UDP, mode: :multicast, parameters: %{}]}
+    {:ok, [transport: :UDP, network_mode: :multicast, mode: :play, parameters: %{}]}
 
     iex> req = %Request{method: "SETUP", headers: [{"Transport", "RTP/AV"}]}
     iex> Request.parse_transport_header(req)

--- a/lib/membrane_rtsp/server/logic.ex
+++ b/lib/membrane_rtsp/server/logic.ex
@@ -1,11 +1,36 @@
 defmodule Membrane.RTSP.Server.Logic do
-  @moduledoc false
+  @moduledoc """
+  Logic for RTSP Server
+  """
+
+  require Logger
+
   import Mockery.Macro
 
   alias Membrane.RTSP.{Request, Response, Server}
 
   @server "MembraneRTSP/#{Mix.Project.config()[:version]} (Membrane Framework RTSP Server)"
-  @allowed_methods ["GET_PARAMETER", "OPTIONS", "DESCRIBE", "SETUP", "PLAY", "PAUSE", "TEARDOWN"]
+  @allowed_methods [
+    "GET_PARAMETER",
+    "OPTIONS",
+    "ANNOUNCE",
+    "DESCRIBE",
+    "SETUP",
+    "PLAY",
+    "RECORD",
+    "PAUSE",
+    "TEARDOWN"
+  ]
+
+  @udp_port_range 1000..65_000//2
+
+  defguardp can_play(state)
+            when map_size(state.configured_media) != 0 and
+                   state.session_state in [:ready, :paused]
+
+  defguardp can_record(state)
+            when map_size(state.incoming_media) != 0 and
+                   state.session_state in [:ready, :paused]
 
   defmodule State do
     @moduledoc false
@@ -17,6 +42,7 @@ defmodule Membrane.RTSP.Server.Logic do
                   :request_handler_state,
                   :session_timeout,
                   configured_media: %{},
+                  incoming_media: %{},
                   session_id: UUID.uuid4(),
                   session_state: :init
                 ]
@@ -28,8 +54,9 @@ defmodule Membrane.RTSP.Server.Logic do
             request_handler: module(),
             request_handler_state: term(),
             configured_media: Server.Handler.configured_media_context(),
+            incoming_media: Server.Handler.configured_media_context(),
             session_id: binary(),
-            session_state: :init | :ready | :playing | :paused,
+            session_state: :init | :ready | :playing | :recording | :paused,
             session_timeout: non_neg_integer()
           }
   end
@@ -37,17 +64,10 @@ defmodule Membrane.RTSP.Server.Logic do
   @spec allowed_methods() :: [binary()]
   def allowed_methods(), do: @allowed_methods
 
-  @spec process_request(binary(), State.t()) :: State.t()
-  def process_request(raw_request, %State{} = state) do
-    {response, state} =
-      case Request.parse(raw_request) do
-        {:ok, request} ->
-          {response, state} = do_handle_request(request, state)
-          {maybe_add_cseq_header(response, request), state}
-
-        {:error, _reason} ->
-          {Response.new(400), state}
-      end
+  @spec process_request(Request.t(), State.t()) :: State.t()
+  def process_request(request, %State{} = state) do
+    {response, state} = do_handle_request(request, state)
+    response = maybe_add_cseq_header(response, request)
 
     response
     |> Response.with_header("Server", @server)
@@ -83,18 +103,22 @@ defmodule Membrane.RTSP.Server.Logic do
     with {:ok, transport_opts} <- Request.parse_transport_header(request),
          :ok <- validate_transport_parameters(transport_opts, state) do
       {response, request_handler_state} =
-        state.request_handler.handle_setup(request, state.request_handler_state)
+        state.request_handler.handle_setup(
+          request,
+          transport_opts[:mode],
+          state.request_handler_state
+        )
 
       {response, state} = do_handle_setup_response(request, response, transport_opts, state)
       {response, %{state | request_handler_state: request_handler_state}}
     else
-      _error ->
+      error ->
+        Logger.error("SETUP request failed due to: #{inspect(error)}")
         {Response.new(400), %{state | request_handler_state: state.request_handler_state}}
     end
   end
 
-  defp do_handle_request(%Request{method: "PLAY"}, state)
-       when state.session_state in [:ready, :paused] do
+  defp do_handle_request(%Request{method: "PLAY"}, state) when can_play(state) do
     {response, request_handler_state} =
       state.request_handler.handle_play(state.configured_media, state.request_handler_state)
 
@@ -120,20 +144,53 @@ defmodule Membrane.RTSP.Server.Logic do
     end
   end
 
+  defp do_handle_request(%Request{method: "ANNOUNCE"} = req, state) do
+    case ExSDP.parse(req.body) do
+      {:ok, sdp} ->
+        {response, request_handler_state} =
+          state.request_handler.handle_announce(
+            %Request{req | body: sdp},
+            state.request_handler_state
+          )
+
+        {response, %{state | request_handler_state: request_handler_state}}
+
+      error ->
+        Logger.error("""
+        ANNOUNCE request failed: could not parse the request body to a valid sdp
+        error: #{inspect(error)}
+        body: #{inspect(req.body, limit: :infinity)}
+        """)
+
+        {Response.new(400), state}
+    end
+
+    {Response.new(200), state}
+  end
+
+  defp do_handle_request(%Request{method: "RECORD"}, state) when can_record(state) do
+    {response, handler_state} = state.request_handler.handle_record(state.incoming_media, state)
+    {response, %{state | request_handler_state: handler_state, session_state: :recording}}
+  end
+
   defp do_handle_request(%Request{method: "TEARDOWN"}, state)
        when state.session_state in [:init, :ready] do
+    close_open_ports(state)
+
     Response.new(200)
     |> inject_session_header(state)
-    |> then(&{&1, %{state | configured_media: %{}, session_state: :init}})
+    |> then(&{&1, %{state | configured_media: %{}, incoming_media: %{}, session_state: :init}})
   end
 
   defp do_handle_request(%Request{method: "TEARDOWN"}, state) do
     {response, _handler_state} =
       state.request_handler.handle_teardown(state.request_handler_state)
 
+    close_open_ports(state)
+
     response
     |> inject_session_header(state)
-    |> then(&{&1, %{state | session_state: :init, configured_media: %{}}})
+    |> then(&{&1, %{state | session_state: :init, configured_media: %{}, incoming_media: %{}}})
   end
 
   defp do_handle_request(%Request{}, state) do
@@ -142,11 +199,16 @@ defmodule Membrane.RTSP.Server.Logic do
 
   # TODO: Add more validation for transport parameters
   defp validate_transport_parameters(transport_opts, state) do
+    transport = transport_opts[:transport]
+
     cond do
-      transport_opts[:mode] == :multicast ->
+      transport_opts[:network_mode] == :multicast ->
         {:error, :multicast_not_supported}
 
-      transport_opts[:transport] == :UDP and is_nil(state.rtp_socket) ->
+      transport_opts[:mode] == :record and transport != :UDP ->
+        {:error, :unsupported_transport}
+
+      transport_opts[:mode] == :play and transport == :UDP and is_nil(state.rtp_socket) ->
         {:error, :udp_not_supported}
 
       true ->
@@ -159,24 +221,36 @@ defmodule Membrane.RTSP.Server.Logic do
 
     if Response.ok?(response) do
       track_config = build_track_config(transport_opts, state)
+
+      state =
+        case transport_opts[:mode] do
+          :play ->
+            %{
+              state
+              | configured_media: Map.put(state.configured_media, request.path, track_config)
+            }
+
+          :record ->
+            %{state | incoming_media: Map.put(state.incoming_media, request.path, track_config)}
+        end
+
       resp_transport_header = build_resp_transport_header(request, track_config)
-
-      configured_media = Map.put(state.configured_media, request.path, track_config)
-
       response = Response.with_header(response, "Transport", resp_transport_header)
 
-      {response,
-       %{
-         state
-         | configured_media: configured_media,
-           session_state: :ready
-       }}
+      {response, %{state | session_state: :ready}}
     else
       {response, state}
     end
   end
 
   defp build_track_config(transport_opts, state) do
+    case transport_opts[:mode] do
+      :play -> build_play_track_config(transport_opts, state)
+      :record -> build_record_track_config(transport_opts, state)
+    end
+  end
+
+  defp build_play_track_config(transport_opts, state) do
     <<ssrc::32>> = :crypto.strong_rand_bytes(4)
 
     case transport_opts[:transport] do
@@ -202,9 +276,63 @@ defmodule Membrane.RTSP.Server.Logic do
     end
   end
 
+  defp build_record_track_config(transport_opts, state) do
+    case transport_opts[:transport] do
+      :TCP ->
+        %{
+          transport: :TCP,
+          tcp_socket: state.socket,
+          channels: transport_opts[:parameters]["interleaved"]
+        }
+
+      :UDP ->
+        case find_rtp_ports(0) do
+          {rtp_socket, rtcp_socket} ->
+            {:ok, {address, _port}} = :inet.peername(state.socket)
+
+            %{
+              transport: :UDP,
+              rtp_socket: rtp_socket,
+              rtcp_socket: rtcp_socket,
+              address: address,
+              client_port: transport_opts[:parameters]["client_port"]
+            }
+
+          :error ->
+            {:error, :udp_port_failure}
+        end
+    end
+  end
+
+  defp find_rtp_ports(attempt) when attempt >= 100, do: :error
+
+  defp find_rtp_ports(attempt) do
+    rtp_port = Enum.random(@udp_port_range)
+
+    case :gen_udp.open(rtp_port, [:binary, active: false]) do
+      {:ok, rtp_socket} ->
+        case :gen_udp.open(rtp_port + 1, [:binary, active: false]) do
+          {:ok, rtcp_socket} ->
+            {rtp_socket, rtcp_socket}
+
+          _error ->
+            :gen_udp.close(rtp_socket)
+            find_rtp_ports(attempt + 1)
+        end
+
+      _error ->
+        find_rtp_ports(attempt + 1)
+    end
+  end
+
   defp build_resp_transport_header(request, track_config) do
     {:ok, req_header} = Request.get_header(request, "Transport")
-    resp_header = req_header <> ";ssrc=#{Integer.to_string(track_config.ssrc, 16)}"
+
+    resp_header =
+      case track_config[:ssrc] do
+        nil -> req_header
+        ssrc -> req_header <> ";ssrc=#{Integer.to_string(ssrc, 16)}"
+      end
 
     case track_config.transport do
       :TCP ->
@@ -232,5 +360,15 @@ defmodule Membrane.RTSP.Server.Logic do
       "Session",
       state.session_id <> ";timeout=#{timeout_in_seconds}"
     )
+  end
+
+  defp close_open_ports(%State{} = state) do
+    state.incoming_media
+    |> Map.values()
+    |> Enum.filter(&(&1.transport == :UDP))
+    |> Enum.each(fn in_media ->
+      :ok = :inet.close(in_media.rtp_socket)
+      :ok = :inet.close(in_media.rtcp_socket)
+    end)
   end
 end

--- a/lib/membrane_rtsp/server/logic.ex
+++ b/lib/membrane_rtsp/server/logic.ex
@@ -175,7 +175,12 @@ defmodule Membrane.RTSP.Server.Logic do
 
   defp do_handle_request(%Request{method: "RECORD"}, state) when can_record(state) do
     {response, handler_state} = state.request_handler.handle_record(state.incoming_media, state)
-    {response, %{state | request_handler_state: handler_state, session_state: :recording}}
+
+    if Response.ok?(response) do
+      {response, %{state | request_handler_state: handler_state, session_state: :recording}}
+    else
+      {response, %{state | request_handler_state: handler_state}}
+    end
   end
 
   defp do_handle_request(%Request{method: "TEARDOWN"}, state)

--- a/lib/membrane_rtsp/server/logic.ex
+++ b/lib/membrane_rtsp/server/logic.ex
@@ -2,10 +2,9 @@ defmodule Membrane.RTSP.Server.Logic do
   @moduledoc """
   Logic for RTSP Server
   """
+  import Mockery.Macro
 
   require Logger
-
-  import Mockery.Macro
 
   alias Membrane.RTSP.{Request, Response, Server}
 

--- a/lib/membrane_rtsp/server/logic.ex
+++ b/lib/membrane_rtsp/server/logic.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.RTSP.Server.Logic do
-  @moduledoc """
-  Logic for RTSP Server
-  """
+  @moduledoc false
+  # Logic for RTSP Server
+
   import Mockery.Macro
 
   require Logger

--- a/lib/membrane_rtsp/server/logic.ex
+++ b/lib/membrane_rtsp/server/logic.ex
@@ -174,7 +174,8 @@ defmodule Membrane.RTSP.Server.Logic do
   end
 
   defp do_handle_request(%Request{method: "RECORD"}, state) when can_record(state) do
-    {response, handler_state} = state.request_handler.handle_record(state.incoming_media, state)
+    {response, handler_state} =
+      state.request_handler.handle_record(state.incoming_media, state.request_handler_state)
 
     if Response.ok?(response) do
       {response, %{state | request_handler_state: handler_state, session_state: :recording}}

--- a/livebook/basic_server.livemd
+++ b/livebook/basic_server.livemd
@@ -3,7 +3,7 @@
 ```elixir
 Mix.install([
   {:membrane_core, "~> 1.0.0"},
-  {:membrane_rtsp, "~> 0.6.0"},
+  {:membrane_rtsp, "~> 0.6"},
   {:membrane_rtp_plugin, "~> 0.24.0"},
   {:membrane_rtp_h264_plugin, "~> 0.19.0"},
   {:membrane_h264_plugin, "~> 0.9"},

--- a/test/membrane_rtsp/server/server_logic_test.exs
+++ b/test/membrane_rtsp/server/server_logic_test.exs
@@ -68,6 +68,59 @@ defmodule Membrane.RTSP.ServerLogicTest do
              Logic.process_request(%Request{method: "DESCRIBE", path: expected_uri}, state)
   end
 
+  describe "handle ANNOUNCE request" do
+    test "announce media streams", %{state: state} do
+      req_body = """
+      v=0
+      o=- 0 0 IN IP4 127.0.0.1
+      s=No Name
+      c=IN IP4 127.0.0.1
+      t=0 0
+      a=tool:libavformat 58.29.100
+      m=video 0 RTP/AVP 96
+      b=AS:1529
+      a=rtpmap:96 H264/90000
+      a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z0LAKNoB4BnsBagICAoAAAMAAgAAAwBkHjBlQA==,aM48gA==; profile-level-id=42C028
+      a=control:streamid=0
+      """
+
+      mock(FakeHandler, [respond: 2], fn %Request{
+                                           body: %ExSDP{session_name: "No Name", media: medias}
+                                         },
+                                         %{} ->
+        assert length(medias) == 1
+        {Response.new(200), %{}}
+      end)
+
+      mock(:gen_tcp, [send: 2], fn %{}, response ->
+        assert response =~ "RTSP/1.0 200 OK"
+      end)
+
+      expected_uri = URI.to_string(@url)
+
+      assert ^state =
+               Logic.process_request(
+                 %Request{method: "ANNOUNCE", body: req_body, path: expected_uri},
+                 state
+               )
+    end
+
+    test "announce with invalid sdp", %{state: state} do
+      req_body = """
+      v=0
+      o=- 0 0 IN IP4 127.0.0.1
+      s=No Name
+      b=X-YZ:256
+      """
+
+      mock(:gen_tcp, [send: 2], fn %{}, response ->
+        assert response =~ "RTSP/1.0 400 Bad Request"
+      end)
+
+      assert ^state = Logic.process_request(%Request{method: "ANNOUNCE", body: req_body}, state)
+    end
+  end
+
   describe "handle SETUP request" do
     test "setup track", %{state: state} do
       control_path = URI.to_string(@url) <> "/trackId=0"
@@ -96,6 +149,44 @@ defmodule Membrane.RTSP.ServerLogicTest do
                  channels: {0, 1}
                }
              } = state.configured_media
+    end
+
+    test "setup record track", %{state: state} do
+      control_path = URI.to_string(@url) <> "/trackId=0"
+
+      mock(FakeHandler, [respond: 2], fn request, %{} ->
+        assert request.path == control_path
+        {Response.new(200), state}
+      end)
+
+      mock(:inet, [peername: 1], fn _socket -> {:ok, {{127, 0, 0, 1}, 0}} end)
+
+      mock(:gen_tcp, [send: 2], fn %{}, response ->
+        assert response =~ "RTSP/1.0 200 OK"
+        assert response =~ "\r\nSession: #{state.session_id};timeout=60\r\n"
+      end)
+
+      state =
+        %Request{method: "SETUP", path: control_path}
+        |> Request.with_header("Transport", "RTP/AVP;unicast;client_port=1000-1001;mode=record")
+        |> Logic.process_request(state)
+
+      assert state.session_state == :ready
+
+      assert %{
+               ^control_path => %{
+                 transport: :UDP,
+                 client_port: {1000, 1001},
+                 rtp_socket: rtp_socket,
+                 rtcp_socket: rtcp_socket
+               }
+             } = state.incoming_media
+
+      assert rtp_socket
+      assert rtcp_socket
+
+      :gen_udp.close(rtp_socket)
+      :gen_udp.close(rtcp_socket)
     end
 
     test "invalid/missing transport header", %{state: state} do

--- a/test/support/fake_handler.ex
+++ b/test/support/fake_handler.ex
@@ -1,12 +1,12 @@
 defmodule Membrane.RTSP.Server.FakeHandler do
   @moduledoc false
 
-  @behaviour Membrane.RTSP.Server.Handler
+  use Membrane.RTSP.Server.Handler
 
   import Mockery.Macro
 
   @impl true
-  def handle_open_connection(_conn), do: %{}
+  def handle_open_connection(_conn, _state), do: %{}
 
   @impl true
   def handle_closed_connection(_state), do: :ok
@@ -17,7 +17,12 @@ defmodule Membrane.RTSP.Server.FakeHandler do
   end
 
   @impl true
-  def handle_setup(request, state) do
+  def handle_setup(request, _mode, state) do
+    mockable(__MODULE__).respond(request, state)
+  end
+
+  @impl true
+  def handle_announce(request, state) do
     mockable(__MODULE__).respond(request, state)
   end
 


### PR DESCRIPTION
Add support for publishing media streams to an RTSP server. In this PR only `udp` transport is supported. We'll add `tcp` support in a  future PR (it needs some thinking since recording with tcp means receiving rtsp messages will be the responsibility of the `handler` and not the server anymore).

I'll add later on an example of a `PubSub Server` where someone is publishing a stream and others streaming it.