### PR TITLE
Skip rtp/rtcp packets sent before play response

### DIFF
--- a/lib/membrane_rtsp/transport.ex
+++ b/lib/membrane_rtsp/transport.ex
@@ -49,6 +49,13 @@ defmodule Membrane.RTSP.Transport do
 
   defp recv(socket, response_timeout, length \\ 0, acc \\ <<>>) do
     case do_recv(socket, response_timeout, length, acc) do
+      # skip rtp/rtcp packets
+      {:ok, <<"$", _channel::8, size::16, _rtp::binary-size(size), rest::binary>>} ->
+        recv(socket, response_timeout, 0, rest)
+
+      {:ok, <<"$", _rest::binary>> = data} ->
+        recv(socket, response_timeout, 0, data)
+
       {:ok, data} ->
         case Response.verify_content_length(data) do
           {:ok, _expected, _received} ->


### PR DESCRIPTION
Since we cannot provide a custom Transport to the rtsp client, we need to handle some edge cases. A reolink camera sends rtp/rtcp data before sending rtsp response to PLAY request. In this PR, we add ability to discard those packets.

This PR also needs #53.