### PR TITLE
Add RFC 2617 qop support and fix SETUP URL handling

### DIFF
--- a/lib/membrane_rtsp/request.ex
+++ b/lib/membrane_rtsp/request.ex
@@ -177,12 +177,10 @@ defmodule Membrane.RTSP.Request do
     if parsed.host do
       %URI{parsed | userinfo: nil} |> URI.to_string()
     else
-      parsed
-      |> Map.get(:path)
+      parsed.path
       |> Path.relative_to(base_url.path)
       |> then(&Path.join(base_url.path, &1))
-      |> then(&Map.put(base_url, :path, &1))
-      |> Map.put(:query, nil)
+      |> then(&%URI{base_url | path: &1, query: nil})
       |> URI.to_string()
     end
   end

--- a/lib/membrane_rtsp/request.ex
+++ b/lib/membrane_rtsp/request.ex
@@ -172,12 +172,19 @@ defmodule Membrane.RTSP.Request do
   defp apply_path(%URI{} = base_url, %__MODULE__{path: nil}), do: base_url
 
   defp apply_path(%URI{} = base_url, %__MODULE__{path: path}) do
-    URI.parse(path)
-    |> Map.get(:path)
-    |> Path.relative_to(base_url.path)
-    |> then(&Path.join(base_url.path, &1))
-    |> then(&Map.put(base_url, :path, &1))
-    |> URI.to_string()
+    %URI{} = parsed = URI.parse(path)
+
+    if parsed.host do
+      %URI{parsed | userinfo: nil} |> URI.to_string()
+    else
+      parsed
+      |> Map.get(:path)
+      |> Path.relative_to(base_url.path)
+      |> then(&Path.join(base_url.path, &1))
+      |> then(&Map.put(base_url, :path, &1))
+      |> Map.put(:query, nil)
+      |> URI.to_string()
+    end
   end
 
   defp render_headers([]), do: ""

--- a/test/membrane_rtsp/request_test.exs
+++ b/test/membrane_rtsp/request_test.exs
@@ -43,6 +43,62 @@ defmodule Membrane.RTSP.RequestTest do
                Factory.SampleOptionsRequest.request()
                |> Request.stringify(Factory.SampleOptionsRequest.url())
     end
+
+    test "strips query string from base URI when path is relative" do
+      # VIVOTEK cameras include query params in stream URI that should not appear in SETUP
+      uri = "rtsp://192.168.1.196:554/media2/stream.sdp?profile=Profile200"
+
+      expected_result = """
+      SETUP rtsp://192.168.1.196:554/media2/stream.sdp/trackID=2 RTSP/1.0
+      CSeq: 4
+      Transport: RTP/AVP;unicast;client_port=57614-57615
+      """
+
+      %Request{
+        method: "SETUP",
+        headers: [{"CSeq", "4"}, {"Transport", "RTP/AVP;unicast;client_port=57614-57615"}],
+        path: "trackID=2"
+      }
+      |> assert_rendered_request(expected_result, uri)
+    end
+
+    test "uses absolute URL directly when path is absolute (RFC 2326)" do
+      # Bosch cameras return absolute control URLs in SDP
+      base_uri = "rtsp://192.168.1.44:554/rtsp_tunnel"
+
+      absolute_control =
+        "rtsp://192.168.1.44:554/rtsp_tunnel?p=0&line=1&inst=1&vcd=2&stream=video"
+
+      expected_result = """
+      SETUP rtsp://192.168.1.44:554/rtsp_tunnel?p=0&line=1&inst=1&vcd=2&stream=video RTSP/1.0
+      CSeq: 4
+      Transport: RTP/AVP;unicast;client_port=57614-57615
+      """
+
+      %Request{
+        method: "SETUP",
+        headers: [{"CSeq", "4"}, {"Transport", "RTP/AVP;unicast;client_port=57614-57615"}],
+        path: absolute_control
+      }
+      |> assert_rendered_request(expected_result, base_uri)
+    end
+
+    test "strips userinfo from absolute control URL" do
+      # Absolute URLs should not leak credentials
+      base_uri = "rtsp://user:pass@192.168.1.44:554/rtsp_tunnel"
+      absolute_control = "rtsp://user:pass@192.168.1.44:554/rtsp_tunnel?p=0&stream=video"
+
+      request = %Request{
+        method: "SETUP",
+        headers: [],
+        path: absolute_control
+      }
+
+      result = Request.stringify(request, URI.parse(base_uri))
+
+      refute String.contains?(result, "user:pass")
+      assert String.contains?(result, "rtsp://192.168.1.44:554/rtsp_tunnel?p=0&stream=video")
+    end
   end
 
   defp assert_rendered_request(request, expected_result, uri_string) do


### PR DESCRIPTION
## Summary
- Add RFC 2617 qop (Quality of Protection) support for digest authentication
- Strip query strings from SETUP URLs when using relative control paths
- Use absolute control URLs directly when provided in SDP (RFC 2326)

## Test plan
- Added tests for qop detection and authentication header generation
- Added tests for absolute URL handling and query string stripping